### PR TITLE
Github test workflows now targets main branch instead of master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,10 @@ name: test
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
     branches:
-    - master
+    - main
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
 | otherwise | patch |
 
 
+## Latest Changes
+
+
+### Internal
+
+* CI - Github workflow tests now targets `main` branch instead of `master`
+
+
 ## Version 1.0.0 Release: Kaiba
 
 Kaiba is a data transformation tool written in Python that uses a DTL(Data Transformation Language) expressed in normal JSON to govern output structure, data fetching and data transformation.


### PR DESCRIPTION
closes: #54 