### PR TITLE
Release 2.0.0 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 ## Latest Changes
 
+## Version 2.0.0 Upgrade dependencies, support python 3.10, 3.11
+
+This major version bump was needed because we upgrade `pydantic` to version 2 from version 1. This changed a lot of error messages in schema validation. If anyone was depending on those, it would break their code. In the same update we are updating a lot of other dependencies too. Most importantly going from `returns` 0.14 to 0.22. This might mean we can make the functional code look better in the future. We are also now support python 3.10 and 3.11 and test them like we do 3.8 and 3.9.
+
 ### Breaking
 
 * Upgrades to `pydantic` version 2. This is a breaking change because it changes the output of validation errors. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kaiba"
-version = "1.0.0"
+version = "2.0.0"
 description = "Configurable and documentable Json transformation and mapping"
 authors = ["Thomas Borgen <thomas.borgen@greenbird.com>"]
 


### PR DESCRIPTION
## Version 2.0.0 Upgrade dependencies, support python 3.10, 3.11

This major version bump was needed because we upgrade `pydantic` to version 2 from version 1. This changed a lot of error messages in schema validation. If anyone was depending on those, it would break their code. In the same update we are updating a lot of other dependencies too. Most importantly going from `returns` 0.14 to 0.22. This might mean we can make the functional code look better in the future. We are also now support python 3.10 and 3.11 and test them like we do 3.8 and 3.9.

### Breaking

* Upgrades to `pydantic` version 2. This is a breaking change because it changes the output of validation errors. 

### Upgrades

* Bumps `returns` to `0.22`

### Internal

* Update `mypy` version
* CI - Github workflow tests now targets `main` branch instead of `master`
