### PR TITLE
Add py.typed file to enable typing downstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 ## Latest Changes
 
+### Upgrades
+
+* Adds a py.typed marker so that when using this package, mypy recognizes it as a typed package.
+
 ## Version 3.0.0 @dataclass from attr bug and no more callable objects.
 
 We were using `@dataclass` decorator from attr, which caused kaiba not to run when used in an environment that did not have attr installed. Thanks to @ChameleonTartu for finding and reporting the bug.


### PR DESCRIPTION
the py.typed file is required by mypy to consider our package typed when imported/used in other projects.


[Mypy documentation](https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages)

> If you would like to publish a library package to a package repository yourself (e.g. on PyPI) for either internal or external use in type checking, packages that supply type information via type comments or annotations in the code should put a py.typed file in their package directory.